### PR TITLE
Filter murr cards by owner

### DIFF
--- a/murr_card/serializers.py
+++ b/murr_card/serializers.py
@@ -23,3 +23,10 @@ class AllMurrSerializer(serializers.ModelSerializer):
     class Meta:
         model = MurrCard
         fields = ('owner_name', 'title', 'cover', 'id')
+
+
+class AllMurrShortSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = MurrCard
+        fields = ('title', 'cover', 'id')

--- a/murr_card/views.py
+++ b/murr_card/views.py
@@ -11,7 +11,9 @@ from rest_framework.views import APIView
 
 from murr_back.settings import LOCALHOST
 from .models import MurrCard
-from .serializers import MurrCardSerializers, EditorImageForMurrCardSerializers, AllMurrSerializer
+from .serializers import (MurrCardSerializers, EditorImageForMurrCardSerializers, AllMurrSerializer,
+                          AllMurrShortSerializer,
+                          )
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +75,18 @@ class MurrPagination(PageNumberPagination):
 
 
 class AllMurr(ListAPIView):
-    queryset = MurrCard.objects.all().order_by('-timestamp')
-    serializer_class = AllMurrSerializer
     pagination_class = MurrPagination
+
+    def get_serializer_class(self):
+        murren_id = self.request.query_params.get('murren_id')
+        if murren_id:
+            return AllMurrShortSerializer
+        return AllMurrSerializer
+
+    def get_queryset(self):
+        murren_id = self.request.query_params.get('murren_id')
+        queryset = MurrCard.objects.all().order_by('-timestamp')
+        if murren_id:
+            queryset = queryset.filter(owner_id=murren_id)
+            return queryset
+        return queryset


### PR DESCRIPTION
Task :
https://trello.com/c/Sp6YUpB2/83-при-get-запросе-через-постмен-на-api-murrcardowner-murrenid1-выдавать-с-писок-всех-мурров-в-виде-cover-title-murrid

Думаю что добавлять отдельный эндпонит `/api/murr_card_owner/?murren_id` не круто.
Уже есть готовый эндпоит `api/murr_card/all/` для вьюхи `AllMurr`, можно просто добавить параметр `murren_id` в запрос и по нему фильтровать. Параметр не обязательный, сериализатор подбирается в зависимости от наличия параметра.